### PR TITLE
Compiling the code that uses rocp v1 and v2 together in ROCm 5.6.0

### DIFF
--- a/issue-114/rocp_v2.c
+++ b/issue-114/rocp_v2.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <rocprofiler.h>
+#include <v2/rocprofiler.h>
 #include "rocp.h"
 
 int rocpv2_foo(void)


### PR DESCRIPTION
Hi @gcongiu ,

Although this patch is not the right fix for [the issue #114 you addressed](https://github.com/ROCm-Developer-Tools/rocprofiler/issues/114), it could be used as the temporary workaround for compiling the code that uses rocprofiler v1 and v2 together. The assumption is that you use the ROCm 5.6.0+.

AFAIK, rocprofiler v2 header file resides in the `rocprofiler/v2/rocprofiler.h` starting from ROCm 5.6.0

Cheers,
Vladimir